### PR TITLE
Tidy up

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,4 @@
 --format documentation
 --color
 --require spec_helper
+-Ilib

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,43 @@
+require: rubocop-rspec
+
+AllCops:
+  Exclude:
+    - 'bin/{console,setup}' # not mine
+    - 'Gemfile'             # maintained through "bundle" command
+
+# TODO: Clean up tests
+RSpec/ExpectInHook:
+  Enabled: false
+RSpec/FilePath:
+  Exclude:
+    - spec/cexpect_spec.rb
+RSpec/MessageSpies:
+  Enabled: false
+RSpec/NestedGroups:
+  Enabled: false
+RSpec/VerifiedDoubles:
+  Enabled: false
+
+# Personal preferences
+Layout/DotPosition:
+  EnforcedStyle: trailing
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%i': '()'
+
+# New stuff in rubocop, not yet enabled/disabled by default
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+Lint/RaiseException:
+  Enabled: true
+Lint/StructNewOverride:
+  Enabled: true
+Style/HashEachMethods:
+  Enabled: true
+Style/HashTransformKeys:
+  Enabled: true
+Style/HashTransformValues:
+  Enabled: true
+
+Style/ExponentialNotation:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,6 @@ gemspec
 
 gem "rake", "~> 12.0"
 gem "rspec", "~> 3.0"
+
+gem "rubocop", "~> 0.82.0"
+gem "rubocop-rspec", "~> 1.38"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,20 @@
 PATH
   remote: .
   specs:
-    cexpect (0.1.0)
+    cexpect (0.1.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.0)
     diff-lcs (1.3)
+    jaro_winkler (1.5.4)
+    parallel (1.19.1)
+    parser (2.7.1.1)
+      ast (~> 2.4.0)
+    rainbow (3.0.0)
     rake (12.3.3)
+    rexml (3.2.4)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -21,6 +28,18 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.2)
+    rubocop (0.82.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.7.0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      rexml
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-rspec (1.38.1)
+      rubocop (>= 0.68.1)
+    ruby-progressbar (1.10.1)
+    unicode-display_width (1.7.0)
 
 PLATFORMS
   ruby
@@ -29,6 +48,8 @@ DEPENDENCIES
   cexpect!
   rake (~> 12.0)
   rspec (~> 3.0)
+  rubocop (~> 0.82.0)
+  rubocop-rspec (~> 1.38)
 
 BUNDLED WITH
    2.1.4

--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ end
 
 wr.puts('cat very-large-file')
 contents = rd.fexpect('$ ')
+
+# If CExpect.spawn doesn't suit you
+orig_rd, wr = IO.pipe
+rd = CExpect::Reader.new(orig_rd)
+
+wr.puts "Hello, World!\n"
+greeting = rd.fexpect("\n")
 ```
 
 ## Development

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,10 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+# frozen_string_literal: true
+
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
+RuboCop::RakeTask.new
 
-task :default => :spec
+task default: %i(spec rubocop)

--- a/cexpect.gemspec
+++ b/cexpect.gemspec
@@ -1,27 +1,32 @@
+# frozen_string_literal: true
+
 require_relative 'lib/cexpect/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "cexpect"
+  spec.name          = 'cexpect'
   spec.version       = Cexpect::VERSION
-  spec.authors       = ["Christer Jansson"]
-  spec.email         = ["christer@janssons.org"]
+  spec.authors       = ['Christer Jansson']
+  spec.email         = ['christer@janssons.org']
 
-  spec.summary       = %q{An improved expect method}
-  spec.description   = %q{An expect method with more reasonable return values and logging functionality}
-  spec.homepage      = "https://github.com/kondensatorn/cexpect"
-  spec.license       = "BSD 2-clause"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  spec.summary       = 'An improved expect method'
+  spec.description   = 'An expect method with more reasonable return' \
+                       ' values and logging functionality'
+  spec.homepage      = 'https://github.com/kondensatorn/cexpect'
+  spec.license       = 'BSD 2-clause'
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.3.0')
 
-  spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = spec.homepage
-  spec.metadata["changelog_uri"] = "#{spec.homepage}/CHANGELOG.md"
+  spec.metadata['homepage_uri'] = spec.homepage
+  spec.metadata['source_code_uri'] = spec.homepage
+  spec.metadata['changelog_uri'] = "#{spec.homepage}/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  # The `git ls-files -z` loads the files in the RubyGem that have
+  # been added into git.
+  spec.files = Dir.chdir(File.expand_path(__dir__)) do
+    `git ls-files -z`.
+      split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
-  spec.bindir        = "exe"
+  spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 end

--- a/lib/cexpect/version.rb
+++ b/lib/cexpect/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Cexpect
-  VERSION = "0.1.0"
+  VERSION = '0.1.1'
 end

--- a/spec/cexpect_spec.rb
+++ b/spec/cexpect_spec.rb
@@ -5,25 +5,26 @@ require 'ostruct'
 # TODO: Haven't figured out how to fix this
 # rubocop:disable Metrics/BlockLength
 RSpec.describe CExpect do
-  context 'expect-style methods' do
+  describe 'expect-style methods' do
     let(:pipe) { OpenStruct.new.tap { |os| os.reader, os.writer = IO.pipe } }
     let(:io) { described_class::Reader.new(pipe.reader) }
 
     let(:filename) { 'a_nice_file.name' }
     let(:output)  { "ls\r\n#{filename}\r\n\r\n> " }
     let(:timeout) { 1 }
+
     before { pipe.writer << output }
 
     describe '#fexpect' do
-      let(:match_data) { io.fexpect(pattern, timeout) }
-
       subject { match_data }
+
+      let(:match_data) { io.fexpect(pattern, timeout) }
 
       context 'when it matches' do
         let(:pattern) { '> ' }
         let(:before_prompt) { output.sub(pattern, '') }
 
-        it { should eq(before_prompt) }
+        it { is_expected.to eq(before_prompt) }
       end
 
       context 'when it times out' do
@@ -38,51 +39,60 @@ RSpec.describe CExpect do
       let(:match_data) { io.expect(pattern, timeout) }
 
       context 'when it times out' do
+        subject { match_data }
+
         let(:pattern) { / will not match! / }
         let(:timeout) { 0 }
-        subject { match_data }
 
         it { is_expected.to be_nil }
       end
 
       context 'when it matches' do
         context 'without captures' do
-          let(:pattern) { filename }
           subject { match_data[0] }
 
-          it { should eq(filename) }
+          let(:pattern) { filename }
+
+          it { is_expected.to eq(filename) }
         end
 
         context 'with anonymous captures' do
-          let(:pattern) { /(#{filename})/ }
           subject { match_data.captures.first }
 
-          it { should eq(filename) }
+          let(:pattern) { /(#{filename})/ }
+
+          it { is_expected.to eq(filename) }
         end
 
         context 'with named captures' do
-          let(:pattern) { /(?<filename>#{filename})/ }
           subject { match_data[:filename] }
 
-          it { should eq(filename) }
+          let(:pattern) { /(?<filename>#{filename})/ }
+
+          it { is_expected.to eq(filename) }
         end
 
         context 'with verbosity' do
+          subject { logger_output }
+
           let(:pattern) { /> / }
           let(:logger_output) { +'' }
           let(:logger) { double('logger') }
+
           before do
-            allow(logger).to receive(:update) { |c| logger_output << c }
+            allow(logger).
+              to receive(:update) { |_pat, buf| logger_output << buf }
             io.add_observer(logger)
             match_data
           end
-          subject { logger_output }
 
-          it { should include(filename) }
+          it { is_expected.to include(filename) }
         end
       end
 
       context 'with block' do
+        subject { match_data }
+
         let(:pattern) { /> / }
         # Add a check that the block is really run
         let(:checker) { double }
@@ -92,19 +102,20 @@ RSpec.describe CExpect do
             md
           end
         end
+
         before { expect(checker).to receive(:check) }
-        subject { match_data }
 
         it { is_expected.to be_kind_of(MatchData) }
       end
     end
   end
 
+  # rubocop: disable RSpec/MultipleExpectations
   describe '.spawn' do
     context 'without block' do
       let(:rv) { described_class.spawn('sh') }
 
-      it 'should return values compatible with PTY.spawn' do
+      it 'returns values compatible with PTY.spawn' do
         psrv = PTY.spawn('sh')
         expect(rv.size).to eq(psrv.size)
         # First element delegates to returned IO
@@ -113,40 +124,44 @@ RSpec.describe CExpect do
         expect(rv[2]).to be_kind_of(psrv[2].class)
       end
 
-      it 'should return a reader, implementing #expect' do
+      it 'returns a reader, implementing #expect' do
         expect(rv.first).to respond_to(:expect)
       end
 
-      it 'should return a reader, implementing #fexpect' do
+      it 'returns a reader, implementing #fexpect' do
         expect(rv.first).to respond_to(:fexpect)
       end
     end
 
     context 'with block' do
-      let(:rv) {
+      let(:rv) do
         described_class.spawn('sh') { |r, w, pid| { args: [r, w, pid] } }
-      }
-
-      it 'should yield as PTY.spawn, and return what the block returns' do
-        psrv = nil # for scope
-        PTY.spawn('sh') { |r, w, pid| psrv = [r, w, pid] }
-        expect(rv).to include(:args)
-        expect(rv[:args].size).to eq(psrv.size)
-        # First object delegates to returned IO
-        expect(rv[:args][0].__getobj__).to be_kind_of(psrv[0].class)
-        expect(rv[:args][1]).to be_kind_of(psrv[1].class)
-        expect(rv[:args][2]).to be_kind_of(psrv[2].class)
       end
 
-      it 'should yield a reader that responds to #expect' do
+      let(:pty_spawn_rv) do
+        psrv = [] # for scope
+        PTY.spawn('sh') { |r, w, pid| psrv.push(r, w, pid) }
+        psrv
+      end
+
+      it 'yields as PTY.spawn, and returns what the block returns' do
+        expect(rv[:args].size).to eq(pty_spawn_rv.size)
+        # First object delegates to returned IO
+        expect(rv[:args][0].__getobj__).to be_kind_of(pty_spawn_rv[0].class)
+        expect(rv[:args][1]).to be_kind_of(pty_spawn_rv[1].class)
+        expect(rv[:args][2]).to be_kind_of(pty_spawn_rv[2].class)
+      end
+
+      it 'yields a reader that responds to #expect' do
         expect(rv[:args].first).to respond_to(:expect)
       end
 
-      it 'should yield a reader that responds to #fexpect' do
+      it 'yields a reader that responds to #fexpect' do
         expect(rv[:args].first).to respond_to(:fexpect)
       end
     end
   end
+  # rubocop: enable RSpec/MultipleExpectations
 end
 
 # rubocop:enable Metrics/BlockLength

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,11 @@
-require "bundler/setup"
-require "cexpect"
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'cexpect'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
-  config.example_status_persistence_file_path = ".rspec_status"
+  config.example_status_persistence_file_path = '.rspec_status'
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!


### PR DESCRIPTION
* Rename private methods in CExpect::Reader
* Introduce rubocop and tidy up
* Update README.md
* Adjust logger interface to let users decide how to handle pattern and
  output