### PR TITLE
Fix bad module name

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cexpect (0.1.2)
+    cexpect (0.1.4)
 
 GEM
   remote: https://rubygems.org/

--- a/cexpect.gemspec
+++ b/cexpect.gemspec
@@ -4,7 +4,7 @@ require_relative 'lib/cexpect/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'cexpect'
-  spec.version       = Cexpect::VERSION
+  spec.version       = CExpect::VERSION
   spec.authors       = ['Christer Jansson']
   spec.email         = ['christer@janssons.org']
 

--- a/lib/cexpect/version.rb
+++ b/lib/cexpect/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-module Cexpect
-  VERSION = '0.1.3'
+module CExpect
+  VERSION = '0.1.4'
 end


### PR DESCRIPTION
The version was in wrongly named Cexpect module, while the
implementation resides in the CExpect module.