### PR TITLE
Fix observer design

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cexpect (0.1.4)
+    cexpect (0.3.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/cexpect.rb
+++ b/lib/cexpect.rb
@@ -11,13 +11,16 @@ module CExpect
   extend CExpect::ModuleMethods
 
   #
-  # A class delegating normal operations to a wrapped IO, adding an
-  # expect method
+  # A class delegating normal operations to a wrapped IO, adding
+  # expect methods
   #
   class Reader < SimpleDelegator
-    def initialize(io, observers = nil)
-      extend(LoggingReader) if observers
-      super(io)
+    def add_observer(*args)
+      extend Observable # overwrites this method with Observable#add_observer
+      # Call the new add_observer method
+      add_observer(*args)
+
+      extend LoggingReader
     end
 
     def expect(pat, timeout = nil, match_method: :re_match)
@@ -71,11 +74,9 @@ module CExpect
   end
 
   #
-  # Adds logging capability when observers are given to constructor
+  # Adds logging capability
   #
   module LoggingReader
-    include Observable
-
     def log(pat, buf)
       return if count_observers.zero?
 

--- a/lib/cexpect/version.rb
+++ b/lib/cexpect/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CExpect
-  VERSION = '0.2.0'
+  VERSION = '0.3.0'
 end

--- a/spec/cexpect_spec.rb
+++ b/spec/cexpect_spec.rb
@@ -78,7 +78,11 @@ RSpec.describe CExpect do
           let(:pattern) { /> / }
           let(:logger_output) { +'' }
           let(:logger) { double('logger') }
-          let(:io) { described_class::Reader.new(pipe.reader, logger) }
+          let(:io) do
+            described_class::Reader.new(pipe.reader).tap do |obj|
+              obj.add_observer(logger)
+            end
+          end
 
           before do
             allow(logger).


### PR DESCRIPTION
The idea to add observers via constructor was not well thought-through,
neither did it work.

From now on, you add loggers as observers, and that's how you make it
logging.

Or whatever you want to use your observers for.